### PR TITLE
Create load balancer for HA Anvils

### DIFF
--- a/hammerspace_locals.tf
+++ b/hammerspace_locals.tf
@@ -114,7 +114,8 @@ locals {
   management_ip_for_url = coalesce(
     # First priority: The floating IP for an HA pair
 
-    local.anvil2_ha_ni_secondary_ip,
+    # local.anvil2_ha_ni_secondary_ip,
+    output.anvil_ha_load_balancer_dns_name,
 
     # Second priority: The IP for a standalone anvil. This checks
     # if a public IP should be used.

--- a/hammerspace_locals.tf
+++ b/hammerspace_locals.tf
@@ -114,8 +114,7 @@ locals {
   management_ip_for_url = coalesce(
     # First priority: The floating IP for an HA pair
 
-    # local.anvil2_ha_ni_secondary_ip,
-    output.anvil_ha_load_balancer_dns_name,
+    local.anvil2_ha_ni_secondary_ip,
 
     # Second priority: The IP for a standalone anvil. This checks
     # if a public IP should be used.

--- a/hammerspace_main.tf
+++ b/hammerspace_main.tf
@@ -643,7 +643,7 @@ resource "aws_lb_listener" "anvil_ha_https" {
 
 resource "aws_lb_target_group_attachment" "anvil_ha_floating_ip" {
   # Only create this if the floating IP has been determined
-  count = local.create_ha_anvils && var.assign_public_ip && local.anvil2_ha_ni_secondary_ip != null ? 1 : 0
+  count = local.create_ha_anvils && var.assign_public_ip ? 1 : 0
 
   target_group_arn = aws_lb_target_group.anvil_ha[0].arn
   target_id        = local.anvil2_ha_ni_secondary_ip

--- a/hammerspace_main.tf
+++ b/hammerspace_main.tf
@@ -292,7 +292,7 @@ resource "aws_volume_attachment" "anvil_meta_vol_attach" {
 
 resource "aws_network_interface" "anvil1_ha_ni" {
   count           = local.create_ha_anvils ? 1 : 0
-  subnet_id       = var.assign_public_ip && var.public_subnet_id != null ? var.public_subnet_id : var.common_config.subnet_id
+  subnet_id       = var.common_config.subnet_id
   security_groups = local.effective_anvil_sg_id != null ? [local.effective_anvil_sg_id] : []
   tags            = merge(local.common_tags,
     { Name = "${var.common_config.project_name}-Anvil1-NI" })
@@ -384,7 +384,7 @@ resource "aws_volume_attachment" "anvil1_meta_vol_attach" {
 
 resource "aws_network_interface" "anvil2_ha_ni" {
   count             = local.create_ha_anvils ? 1 : 0
-  subnet_id         = var.assign_public_ip && var.public_subnet_id != null ? var.public_subnet_id : var.common_config.subnet_id
+  subnet_id         = var.common_config.subnet_id
   security_groups   = local.effective_anvil_sg_id != null ? [local.effective_anvil_sg_id] : []
   private_ips_count = 1
   tags              = merge(local.common_tags,

--- a/hammerspace_outputs.tf
+++ b/hammerspace_outputs.tf
@@ -34,6 +34,7 @@ output "management_url" {
     local.create_ha_anvils && var.assign_public_ip && length(aws_lb.anvil_ha) > 0 ?
     "https://${one(aws_lb.anvil_ha[*].dns_name)}" :
     local.management_ip_for_url != "N/A - Anvil instance details not available." ? "https://${local.management_ip_for_url}" : "N/A"
+  )
 }
 
 output "anvil_instances" {

--- a/hammerspace_outputs.tf
+++ b/hammerspace_outputs.tf
@@ -35,7 +35,7 @@ output "management_url" {
 
 output "anvil_instances" {
   description = "Details of deployed Anvil instances."
-  sensitive   = false
+  sensitive   = true
   value = local.create_standalone_anvil && length(aws_instance.anvil) > 0 ? [
     {
       type                       = "standalone"
@@ -86,7 +86,7 @@ output "dsx_instances" {
       id              = inst.id
       arn	      = inst.arn
       private_ip      = inst.private_ip
-      public_ip       = var.assign_public_ip ? inst.public_ip : null
+      public_ip       = inst.public_ip
       key_name        = inst.key_name
       iam_profile     = inst.iam_instance_profile
       placement_group = inst.placement_group

--- a/hammerspace_outputs.tf
+++ b/hammerspace_outputs.tf
@@ -30,7 +30,10 @@ output "management_ip" {
 
 output "management_url" {
   description = "Management URL for the Hammerspace cluster."
-  value       = local.management_ip_for_url != "N/A - Anvil instance details not available." ? "https://${local.management_ip_for_url}" : "N/A"
+  value       = (
+    local.create_ha_anvils && var.assign_public_ip && length(aws_lb.anvil_ha) > 0 ?
+    "https://${one(aws_lb.anvil_ha[*].dns_name)}" :
+    local.management_ip_for_url != "N/A - Anvil instance details not available." ? "https://${local.management_ip_for_url}" : "N/A"
 }
 
 output "anvil_instances" {


### PR DESCRIPTION
No more public IP's for the HA Anvil. Use a load balancer instead.